### PR TITLE
Changes to accept v480.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter v400 v410, $(TARGET_DEVICE)),)
+ifneq ($(filter v400 v410 v480, $(TARGET_DEVICE)),)
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
 

--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -19,7 +19,7 @@
 
 #define BLUETOOTH_QTI_SW TRUE
 
-#define BTM_DEF_LOCAL_NAME   "LG G Pad 7"
+#define BTM_DEF_LOCAL_NAME   "LG G Pad"
 // Disables read remote device feature
 #define BTA_SKIP_BLE_READ_REMOTE_FEAT TRUE
 #define MAX_L2CAP_CHANNELS    14

--- a/wcnss_lge/Android.mk
+++ b/wcnss_lge/Android.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifneq ($(filter v400 v410,$(TARGET_DEVICE)),)
+ifneq ($(filter v400 v410 v480,$(TARGET_DEVICE)),)
 
 LOCAL_PATH:= $(call my-dir)
 


### PR DESCRIPTION
These are some changes to make it work on v480 (LG G Pad 8.0). Also, I removed the "7" from bluetooth name, since this repository can be used for both G Pad 7 and G Pad 8.